### PR TITLE
Use system ruby in shebang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Continuous Integration
 on:
   push:
-    branches: [master, main]
+    branches: [main]
   pull_request:
   workflow_dispatch:
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,15 @@
 name: Continuous Integration
 on:
   push:
-    branches: [master]
+    branches: [master, main]
   pull_request:
+  workflow_dispatch:
 jobs:
   ruby:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7]
+        ruby: [3.0, 3.1, 3.2, 3.3]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 AllCops:
   # this version is based on the current requirements of FB cookbooks,
   # even though we are on a later version of Ruby
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 3.0
   NewCops: enable
 
 # Disabled rules

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 gemspec
 
 group :test, :development do
-  gem 'rubocop', '~> 0.55.0'
+  gem 'rubocop', '~> 1.62'
 end

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 [![Continuous Integration](https://github.com/vicariousinc/setup-oob/workflows/Continuous%20Integration/badge.svg)](https://github.com/vicariousinc/setup-oob/actions?query=workflow%3AContinuous%20Integration)
 
+*NOTE*: This is a fork of
+[viariousinc/setup-oob](https://github.com/vicariousinc/setup-oob) which is
+defunct. This is now the official respository, feel free to send PRs or issues
+here.
+
 This is a utility for configuring out-of-band management systems from within
 the running (Linux) OS.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Setup OOB
 
-[![Continuous Integration](https://github.com/vicariousinc/setup-oob/workflows/Continuous%20Integration/badge.svg)](https://github.com/vicariousinc/setup-oob/actions?query=workflow%3AContinuous%20Integration)
+[![Continuous Integration](https://github.com/jaymzh/setup-oob/workflows/Continuous%20Integration/badge.svg)](https://github.com/jaymzh/setup-oob/actions?query=workflow%3AContinuous%20Integration)
 
 *NOTE*: This is a fork of
 [viariousinc/setup-oob](https://github.com/vicariousinc/setup-oob) which is

--- a/bin/setup-oob
+++ b/bin/setup-oob
@@ -1,4 +1,4 @@
-#!/opt/chef/embedded/bin/ruby
+#!/usr/bin/env ruby
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2021-present Vicarious

--- a/lib/setup_oob/command/smc.rb
+++ b/lib/setup_oob/command/smc.rb
@@ -142,7 +142,7 @@ class SMCCommands
       en = out[0] == 1
       # when you check if NTP is enabled, a bunch of extra bytes
       # are passed back that MUST be passed in when enabling NTP
-      @_magic = out[1..-1]
+      @_magic = out[1..]
       logger.debug("NTP enabled: #{en}, magic bytes: #{@_magic}")
       en
     end

--- a/setup-oob.gemspec
+++ b/setup-oob.gemspec
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require_relative './lib/setup_oob/version'
+require_relative 'lib/setup_oob/version'
 
 Gem::Specification.new do |s|
   s.name = 'setup_oob'
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/vicariousinc/setup-oob'
   s.platform = Gem::Platform::RUBY
   s.extra_rdoc_files = %w{README.md LICENSE CHANGELOG.md}
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 3.0'
 
   s.bindir = %w{bin}
   s.executables = %w{setup-oob}
@@ -34,4 +34,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'ipaddress'
   s.add_dependency 'mixlib-shellout'
+  s.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
This is currently hardcoded to the embedded Chef ruby, which isn't generally available unless one has Chef installed. Switch to the system one instead.